### PR TITLE
Fix env variable name in config connector lab

### DIFF
--- a/10-config-connector/00-configconnector.yaml
+++ b/10-config-connector/00-configconnector.yaml
@@ -6,4 +6,4 @@ metadata:
   name: configconnector.core.cnrm.cloud.google.com
 spec:
   mode: cluster
-  googleServiceAccount: "config-connector-sa@${GCP_PROJECT}.iam.gserviceaccount.com"
+  googleServiceAccount: "config-connector-sa@${PROJECT_ID}.iam.gserviceaccount.com"

--- a/10-config-connector/01-namespace.yaml
+++ b/10-config-connector/01-namespace.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    cnrm.cloud.google.com/project-id: ${GCP_PROJECT}
+    cnrm.cloud.google.com/project-id: ${PROJECT_ID}
   name: doit-lab-10

--- a/10-config-connector/03-iam.yaml
+++ b/10-config-connector/03-iam.yaml
@@ -19,7 +19,7 @@ spec:
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
-    external: projects/${GCP_PROJECT}
+    external: projects/${PROJECT_ID}
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
@@ -27,7 +27,7 @@ metadata:
   name: pubsub-sa-workloadidentity
   namespace: doit-lab-10
 spec:
-  member: serviceAccount:${GCP_PROJECT}.svc.id.goog[doit-lab-10/pubsub-sa]
+  member: serviceAccount:${PROJECT_ID}.svc.id.goog[doit-lab-10/pubsub-sa]
   role: roles/iam.workloadIdentityUser
   resourceRef:
     apiVersion: iam.cnrm.cloud.google.com/v1beta1

--- a/10-config-connector/04-serviceaccount.yaml
+++ b/10-config-connector/04-serviceaccount.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: pubsub-sa@${GCP_PROJECT}.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: pubsub-sa@${PROJECT_ID}.iam.gserviceaccount.com
   name: pubsub-sa
   namespace: doit-lab-10


### PR DESCRIPTION
Otherwise `envsubst` fails to replace it.
