### PR TITLE
Update 05-pubsub-deployment.yaml

### DIFF
--- a/10-config-connector/05-pubsub-deployment.yaml
+++ b/10-config-connector/05-pubsub-deployment.yaml
@@ -15,4 +15,4 @@ spec:
       serviceAccountName: pubsub-sa
       containers:
         - name: subscriber
-          image: us-docker.pkg.dev/google-samples/containers/gke/pubsub-sample:v1
+          image: us-docker.pkg.dev/google-samples/containers/gke/pubsub-sample:v2


### PR DESCRIPTION
Changing the version of the image to `v2` as the `v1` version has been deleted [1].

[1] https://console.cloud.google.com/artifacts/docker/google-samples/us/containers/gke%2Fpubsub-sample?inv=1&invt=Ab0BDw